### PR TITLE
fix: Corriger la troncature des noms avec caractères accentués

### DIFF
--- a/services/gmail.js
+++ b/services/gmail.js
@@ -151,7 +151,7 @@ export class GmailService {
     };
 
     // Extraction du nom de l'expéditeur
-    const senderMatch = emailContent.match(/(\w+\s+\w+)\s+vous a envoyé/);
+    const senderMatch = emailContent.match(/([\p{L}\p{M}]+\s+[\p{L}\p{M}]+(?:\s+[\p{L}\p{M}]+)*)\s+vous a envoyé/u);
     if (senderMatch) result.sender = senderMatch[1];
 
     // Extraction des frais


### PR DESCRIPTION
Le regex \w+ ne matche que les caractères ASCII, ce qui tronquait
les noms contenant des accents (ex: "Loïc" → "c"). Remplacement
par [\p{L}\p{M}]+ avec le flag Unicode pour supporter tous les
caractères alphabétiques et diacritiques.

https://claude.ai/code/session_01WaUFjL6FoEZ1ePntMoJJJ4