### PR TITLE
fix: Supporter les montants >= 1000€ avec séparateur de milliers

### DIFF
--- a/services/gmail.js
+++ b/services/gmail.js
@@ -41,7 +41,7 @@ export class GmailService {
             const parsedEmail = this.parsePayPalEmail(emailType, date, content);
             if (parsedEmail) {
               const currentAmount = parseFloat(
-                parsedEmail.amount?.split(" ")[0].trim().replace(",", ".")
+                parsedEmail.amount?.replace(/[^\d,]/g, "").replace(",", ".")
               );
               amountSum += currentAmount * (emailType === "received" ? 1 : -1);
               console.log(
@@ -170,7 +170,7 @@ export class GmailService {
     } else {
       // Pas de frais, on extrait le montant directement
       const amountMatch = emailContent.match(
-        /vous a envoyé\s([\d,]+\s*€\s*EUR)/
+        /vous a envoyé\s([\d\s\u00a0,]+\s*€\s*EUR)/
       );
       if (amountMatch) result.amount = amountMatch[1];
     }
@@ -214,7 +214,7 @@ export class GmailService {
 
     // Extraction du montant
     const amountMatch = emailContent.match(
-      /envoyé ([0-9]+,[0-9]{2}\s*€?\s*EUR)/
+      /envoyé ([0-9\s\u00a0]+,[0-9]{2}\s*€?\s*EUR)/
     );
     if (amountMatch) result.amount = amountMatch[1];
 


### PR DESCRIPTION
Les montants comme "1 600,00 € EUR" n'étaient pas capturés car les regex [\d,]+ et [0-9]+ ne gèrent pas les espaces utilisés comme séparateurs de milliers. Ajout de \s\u00a0 dans les patterns.

Correction aussi du parseFloat qui faisait split(" ")[0] sur le montant, retournant "1" au lieu de "1600.00" pour "1 600,00 € EUR".

https://claude.ai/code/session_01WaUFjL6FoEZ1ePntMoJJJ4