### PR TITLE
feat: Ajouter la gestion des paiements d'abonnement (Netflix, etc.)

### DIFF
--- a/netlify/functions/checkpaypalpayments/checkpaypalpayments.mjs
+++ b/netlify/functions/checkpaypalpayments/checkpaypalpayments.mjs
@@ -53,7 +53,7 @@ export default async (request, context) => {
 
       for (const email of emails) {
 
-        if (email.type === "received") {
+        if (email.type === "received" || email.type === "subscription") {
           await telegramService.sendPayPalNotification(email);
           continue;
         }

--- a/services/telegram.js
+++ b/services/telegram.js
@@ -11,6 +11,8 @@ export class TelegramService {
   async sendPayPalNotification(paymentInfo, imageBuffer = null) {
     if (paymentInfo.type === "sent") {
       await this.sendSentPaymentNotification(paymentInfo, imageBuffer);
+    } else if (paymentInfo.type === "subscription") {
+      await this.sendSubscriptionPaymentNotification(paymentInfo);
     } else {
       await this.sendReceivedPaymentNotification(paymentInfo);
     }
@@ -36,6 +38,31 @@ export class TelegramService {
     } catch (error) {
       console.error(
         "[sendReceivedPaymentNotification@TelegramService]",
+        "Erreur lors de l'envoi du message Telegram:",
+        error
+      );
+    }
+  }
+
+  async sendSubscriptionPaymentNotification(paymentInfo) {
+    const message = `
+🔔 Paiement d'abonnement PayPal !
+
+🏪 Marchand : ${paymentInfo.merchant}
+💵 Montant : *${paymentInfo.amount}*
+📅 Date : ${paymentInfo.date}
+🕒 Heure : ${paymentInfo.time}
+🔢 N° de commande : ${paymentInfo.orderNumber}
+🔢 Référence : ${paymentInfo.reference}
+`;
+
+    try {
+      await this.bot.sendMessage(telegramConfig.chatId, message, {
+        parse_mode: "Markdown",
+      });
+    } catch (error) {
+      console.error(
+        "[sendSubscriptionPaymentNotification@TelegramService]",
         "Erreur lors de l'envoi du message Telegram:",
         error
       );


### PR DESCRIPTION
Nouveau type d'email "subscription" détecté via le sujet "Reçu pour votre paiement". Parse le marchand, montant, date, n° de commande et référence de transaction. Envoie une notification Telegram dédiée et débite le solde PayPal en base de données.

https://claude.ai/code/session_01WaUFjL6FoEZ1ePntMoJJJ4