### PR TITLE
fix: Supporter les différentes structures HTML des mails marchands

### DIFF
--- a/services/gmail.js
+++ b/services/gmail.js
@@ -268,14 +268,16 @@ export class GmailService {
     }
 
     // Extraction de la date depuis le tableau HTML
+    // Format Netflix : Date de la transaction</span></span></td><td><span><span>valeur
+    // Format Airbnb  : Date de la transaction</strong></span><br><span><span>valeur
     const dateMatch = emailContent.match(
-      /Date de la transaction<\/span><\/span><\/td>\s*<td[^>]*><span[^>]*><span>([^<]+)/
+      /Date de la transaction<\/(?:span|strong)><\/span>(?:<\/td>\s*<td[^>]*>|<br>)<span[^>]*><span>([^<]+)/
     );
     if (dateMatch) result.date = dateMatch[1].trim();
 
-    // Extraction du n° de commande
+    // Extraction du n° de commande ou numéro de facture
     const orderMatch = emailContent.match(
-      /N° de commande<\/span><\/span><\/td>\s*<td[^>]*><span[^>]*><span>([^<]+)/
+      /(?:N° de commande|Numéro de facture)<\/(?:span|strong)><\/span>(?:<\/td>\s*<td[^>]*>|<br>)<span[^>]*><span>([^<]+)/
     );
     if (orderMatch) result.orderNumber = orderMatch[1].trim();
 

--- a/services/telegram.js
+++ b/services/telegram.js
@@ -45,16 +45,18 @@ export class TelegramService {
   }
 
   async sendSubscriptionPaymentNotification(paymentInfo) {
-    const message = `
+    let message = `
 🔔 Paiement d'abonnement PayPal !
 
 🏪 Marchand : ${paymentInfo.merchant}
 💵 Montant : *${paymentInfo.amount}*
 📅 Date : ${paymentInfo.date}
-🕒 Heure : ${paymentInfo.time}
-🔢 N° de commande : ${paymentInfo.orderNumber}
-🔢 Référence : ${paymentInfo.reference}
-`;
+🕒 Heure : ${paymentInfo.time}`;
+
+    if (paymentInfo.orderNumber) {
+      message += `\n🔢 N° de commande : ${paymentInfo.orderNumber}`;
+    }
+    message += `\n🔢 Référence : ${paymentInfo.reference}\n`;
 
     try {
       await this.bot.sendMessage(telegramConfig.chatId, message, {


### PR DESCRIPTION
Les mails PayPal de marchands ont deux formats HTML différents :
- Netflix : label et valeur dans des <td> séparés
- Airbnb  : label et valeur dans le même <td>, séparés par <br>

Les regex de date et n° de commande gèrent maintenant les deux formats. Ajout du support "Numéro de facture" (Airbnb) en plus de "N° de commande" (Netflix). Le champ N° de commande est optionnel dans le message Telegram.

https://claude.ai/code/session_01WaUFjL6FoEZ1ePntMoJJJ4